### PR TITLE
careers: render all job posts

### DIFF
--- a/content/careers/_index.md
+++ b/content/careers/_index.md
@@ -1,5 +1,5 @@
 +++
 title = "Tlon Corporation - Careers"
-sort_by = "date"
 template = "careers.html"
+page_template = "careers-post.html"
 +++

--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -20,7 +20,7 @@ html { font-family: 'Inter var', sans-serif; }
   -webkit-font-smoothing: antialiased;
 }
 
-.editorial > p, ol, h2 {
+.editorial > p, .editorial > ol, .editorial > ul, .editorial > h2 {
     @media (min-width: 1024px) { width: 58.333333%; }
     margin: auto;
     font-family: "Untitled-Serif", serif;

--- a/templates/careers-post.html
+++ b/templates/careers-post.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}
+<meta name="og:title" content="{{ page.title }} - {{ config.title }}">
+<meta name="twitter:title" content="{{ page.title }} - {{ config.title }}">
+<title>{{ page.title }} - {{ config.title }}</title>
+{% endblock title %}
+{% block content %}
+{% include "partials/nav.html" %}
+<article class="p-8 lg:p-16 lg:w-10/12 container mx-auto">
+
+  <header class="box-border lg:w-7/12 pb-16 m-auto">
+    <h1 class="text-3xl font-medium pb-2">{{ page.title }}</h1>
+    {% if page.extra.location %}
+    <p class="text-gray-400">{{ page.extra.location }}</p>
+    {% else %}
+    <p class="text-gray-400">Remote</p>
+    {% endif %}
+  </header>
+
+  <section class="editorial pt-16 leading-relaxed text-lg lg:text-xl font-serif">
+    {{ page.content | safe }}
+  </section>
+</article>
+{% endblock content %}

--- a/templates/careers.html
+++ b/templates/careers.html
@@ -14,9 +14,22 @@
   </section>
   <section class='py-16 text-sm pt-32'>
     <h1 class="text-3xl font-medium">Openings</h1>
-<!-- TODO: Add a loop for the opening posts. -->
-  <section class="pt-32">
-    <h4 class="font-medium text-sm">General Availability</h4>
+  <section class="pt-24">
+    {% for page in section.pages %}
+    <a href="{{ page.permalink | safe }}">
+      <div>
+        <h4 class="font-medium text-sm pt-8">{{ page.title }}</h4>
+        <p class="text-gray-400 text-sm">
+          {% if page.extra.location %}
+            {{ page.extra.location }}
+          {% else %}
+            Remote
+          {% endif %}
+        </p>
+      </div>
+    </a>
+    {% endfor %}
+    <h4 class="font-medium text-sm pt-8">General Availability</h4>
     <p class="text-gray-400 text-sm">Remote</p>
     <p class="text-sm max-w-2xl pt-4"><i>"The contact and the habit of Tlon have disintegrated this world."</i>
     <p class="pt-4">We're looking for world enders and rebuilders.</p>


### PR DESCRIPTION
Renders all job postings on careers page. Job posts are added as markdown files in the content/careers folder, requiring only a Title in the toml metadata, nothing else. Adding 'location' under `[extra]` will render the location on the posting and in the list instead of 'Remote', which is the default and the fallback value.

Screenshots and sample job posting —

![careers](https://user-images.githubusercontent.com/20846414/126401263-70b9b43f-f98a-4f57-b5f3-afaa9ff34398.png)

![careers-post](https://user-images.githubusercontent.com/20846414/126401288-12e10e2b-732d-4069-ba7b-120331e39486.png)
